### PR TITLE
fix: failing tests in metamask.spec.js

### DIFF
--- a/packages/tools/src/metamask.js
+++ b/packages/tools/src/metamask.js
@@ -211,7 +211,7 @@ export class Metamask extends Emittery {
 
     // import wallet
 
-    await click(page.getByTestId('onboarding-terms-checkbox'))
+    await page.getByTestId('onboarding-terms-checkbox').click()
     await page.getByTestId('onboarding-import-wallet').click()
     await page.getByTestId('metametrics-no-thanks').click()
 
@@ -312,7 +312,7 @@ export class Metamask extends Emittery {
   }
 
   /**
-   * Install a snap
+   * Get snaps
    *
    * @param {import('@playwright/test').Page} page - Page to run getSnaps
    */


### PR DESCRIPTION
Fixes 3 out of 4 test failures in `metamask.spec.js`. I've hit a time restraint where I need to move back onto my task for testing #25, but at least this is progress.

Explanation of remaining failure in #26